### PR TITLE
Fix hotkey handling with more debug info

### DIFF
--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -1,6 +1,5 @@
 """Defines the Python API for interacting with the StreamDeck Configuration UI"""
 import json
-import traceback
 import sys
 import os
 from pathlib import Path

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -47,12 +47,10 @@ def _key_change_callback(deck_id: str, _deck: StreamDeck.StreamDeck, key: int, s
                         keycode = getattr(Key, key_name.lower(), key_name)
                         keyboard.press(keycode)
                         pressed_keys.append(key_name)
-                except Exception:
+                except Exception as e:
                     try:
-                        exc_info = sys.exc_info()
-                        print("An exception '{}' occured during Key press of {} (keycode: {})".format(exc_info[0], key_name, keycode))
-                        traceback.print_exception(*exc_info)
-                        del exc_info
+                        print("An exception '{}' occured during Key press of {} (keycode: {}): {}"
+                            .format(sys.exc_info()[0], key_name, keycode, getattr(e, "message", e)))
                         pass
                     except:
                         pass

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -275,13 +275,13 @@ def start(_exit: bool = False) -> None:
 
     items = api.open_decks().items()
     print("wait for device(s)")
-    
+
     while len(items) == 0:
         time.sleep(3)
         items = api.open_decks().items()
-    
-    print("found " + str(len(items)))
-    
+
+    print("found " + str(len(items)) + ": " + ",".join(str(i) for i in list(items)) )
+
     for deck_id, deck in items:
         ui.device_list.addItem(f"{deck['type']} - {deck_id}", userData=deck_id)
 
@@ -302,7 +302,7 @@ def start(_exit: bool = False) -> None:
     tray.show()
     if first_start:
         main_window.show()
-    
+
     if _exit:
         return
     else:


### PR DESCRIPTION
I struggled with multiple bugs in this updated version, and this helped me debug following issues:

- my XL board was reading garbled data on the serial, which added \0 in key name (https://github.com/abcminiuser/python-elgato-streamdeck/issues/58) 
- Media keys were not working due to bad prefix in pynput (https://github.com/moses-palmer/pynput/issues/313)
- bad keys were not handled in upstream version and broke the event loop.

This update add more detailed message:
```
An exception '<class 'pynput._util.xorg.X11Error'>' occured during Key press of media_volume_mute (keycode: Key.media_volume_mute): [(BadValue(<Xlib.display._BaseDisplay object at 0x7f73df704f50>, b'\x00\x02\x13\x00\x00\x00\x00\x00\x02\x00\x84\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'), None)]
An exception '<class 'pynput._util.xorg.X11Error'>' occured during Key press of media_volume_down (keycode: Key.media_volume_down): [(BadValue(<Xlib.display._BaseDisplay object at 0x7f73df704f50>, b'\x00\x02\x18\x00\x00\x00\x00\x00\x02\x00\x84\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'), None)]
```
And releases the keys already pressed, if a bad key is set in the group.